### PR TITLE
Fixed adding data to database with foreign key

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -8,8 +8,8 @@ from sqlmodel import SQLModel, Field
 class LogStartStop(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     proc_id: str
-    started: datetime
-    stopped: datetime
+    started: Optional[datetime] = None
+    stopped: Optional[datetime] = None
     process_id: int = Field(default=None, foreign_key="process.id")
 
 

--- a/ui/all_processes_ui.py
+++ b/ui/all_processes_ui.py
@@ -53,7 +53,8 @@ to change width of column drag boundary
             self.tree.insert('', 'end', values=item)
             # adjust column's width if necessary to fit each value
             for ix, val in enumerate(item):
-                col_w = tkFont.Font().measure(val)
+                if val is not None:
+                    col_w = tkFont.Font().measure(val)
                 if self.tree.column(process_header[ix], width=None) < col_w:
                     self.tree.column(process_header[ix], width=col_w)
 


### PR DESCRIPTION
Modified models adding Optional to both started and stopped. My thinking, the process is either running or it isn't. The database will still have start times if the process is started when a capture happens. But if it is stopped then I don't want to confuse the user by showing a previous start time along with a stop time. They can get that from historical data. 

A future feature could be graphing this type of data in application.